### PR TITLE
Call matrix_init_quantum from matrix_init instead of matrix_init_user

### DIFF
--- a/keyboards/jorne_ble/master/master.c
+++ b/keyboards/jorne_ble/master/master.c
@@ -43,7 +43,7 @@ void select_row(uint8_t row);
 matrix_row_t read_cols(void);
 static bool bootloader_flag = false;
 
-void matrix_init_user() {
+void matrix_init_kb() {
   nrfmicro_init();
 
   select_row(3);
@@ -60,12 +60,14 @@ void matrix_init_user() {
   #ifdef SSD1306OLED
       iota_gfx_init(!IS_LEFT_HAND);   // turns on the display
   #endif
+  matrix_init_user();
 }
 
-void matrix_scan_user(void) {
+void matrix_scan_kb(void) {
   #ifdef SSD1306OLED
     iota_gfx_task();  // this is what updates the display continuously
   #endif
 
   nrfmicro_update();
+  matrix_scan_user();
 }

--- a/tmk_core/protocol/nrf/matrix.c
+++ b/tmk_core/protocol/nrf/matrix.c
@@ -181,7 +181,7 @@ void matrix_init(void) {
 #if defined(USE_AS_I2C_SLAVE)
   i2cs_init();
 #endif
-  matrix_init_user();
+  matrix_init_quantum();
 }
 
 static inline void set_received_key(ble_switch_state_t key, bool from_slave) {


### PR DESCRIPTION
Makes the behavior identical to non-NRF QMK.
Fixes https://github.com/joric/qmk/issues/6

<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* #6 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
